### PR TITLE
(ngx) add compatilibity with @ionic-native/core@5.x.x

### DIFF
--- a/ngx/index.d.ts
+++ b/ngx/index.d.ts
@@ -1,0 +1,129 @@
+import { IonicNativePlugin } from '@ionic-native/core';
+export declare class KakaoCordovaSDK extends IonicNativePlugin {
+    login(loginOptions: any): Promise<any>;
+    logout(): Promise<any>;
+    unlinkApp(): Promise<any>;
+    getAccessToken(): Promise<string>;
+    requestMe(): Promise<string>;
+    updateScopes(targetScopes: any): Promise<string>;
+    checkScopeStatus(targetScopes: any): Promise<string>;
+    requestSendMemo(builder: any): Promise<string>;
+    addPlusFriend(params: any): Promise<string>;
+    chatPlusFriend(params: any): Promise<string>;
+    chatPlusFriendUrl(params: any): Promise<string>;
+    sendLinkFeed(feedTemplate: KLFeedTemplate): Promise<string>;
+    sendLinkList(listTemplate: KLListTemplate): Promise<string>;
+    sendLinkLocation(locationTemplate: KLLocationTemplate): Promise<string>;
+    sendLinkCommerce(listTemplate: KLCommerceTemplate): Promise<string>;
+    sendLinkText(textTemplate: KLTextTemplate): Promise<string>;
+    sendLinkScrap(scrapTemplate: KLScrapTemplate): Promise<string>;
+    sendLinkCustom(customTemplate: KLCustomTemplate): Promise<string>;
+    uploadImage(uploadImageConfig: KLUploadImageConfig): Promise<string>;
+    deleteUploadedImage(deleteImageConfig: KLDeleteImageConfig): Promise<string>;
+    postStory(postStoryConfig: KLPostStoryConfig): Promise<string>;
+}
+export declare enum ScrapType {
+    ScrapTypeNone = 0,
+    ScrapTypeWebsite,
+    ScrapTypeVideo,
+    ScrapTypeMusic,
+    ScrapTypeBook,
+    ScrapTypeArticle,
+    ScrapTypeProfile,
+}
+export interface KLPostStoryUrlInfo {
+    title: string;
+    desc?: string;
+    imageURLs?: string[];
+    type?: ScrapType;
+}
+export interface KLPostStoryConfig {
+    post: string;
+    appid?: string;
+    appver: string;
+    appname?: string;
+    urlinfo?: KLPostStoryUrlInfo;
+}
+export interface KLDeleteImageConfig {
+    url: string;
+}
+export interface KLUploadImageConfig {
+    fileOrUrl: 'file' | 'url';
+    url?: string;
+}
+export interface KLCustomTemplate {
+    templateId: string;
+    arguments?: any;
+}
+export interface KLScrapTemplate {
+    url: string;
+}
+export interface KLTextTemplate {
+    text: string;
+    link: KLLinkObject;
+    buttonTitle?: string;
+    buttons?: KLButtonObject[];
+}
+export interface KLCommerceTemplate {
+    content: KLContentObject;
+    commerce: KLCommerceObject;
+    buttonTitle?: string;
+    buttons?: KLButtonObject[];
+}
+export interface KLLocationTemplate {
+    address: string;
+    content: KLContentObject;
+    addressTitle?: string;
+    social?: KLSocialObject;
+    buttonTitle?: string;
+    buttons?: KLButtonObject[];
+}
+export interface KLListTemplate {
+    headerTitle: string;
+    headerLink: KLLinkObject;
+    contents: KLContentObject[];
+    buttonTitle?: string;
+    buttons?: KLButtonObject[];
+}
+export interface KLFeedTemplate {
+    content: KLContentObject;
+    social?: KLSocialObject;
+    buttonTitle?: string;
+    buttons?: KLButtonObject[];
+}
+export interface KLContentObject {
+    title: string;
+    link: KLLinkObject;
+    imageURL: string;
+    desc?: string;
+    imageWidth?: string;
+    imageHeight?: string;
+}
+export interface KLLinkObject {
+    webURL?: string;
+    mobileWebURL?: string;
+    androidExecutionParams?: string;
+    iosExecutionParams?: string;
+}
+export interface KLSocialObject {
+    likeCount?: number;
+    commentCount?: number;
+    sharedCount?: number;
+    viewCount?: number;
+    subscriberCount?: number;
+}
+export interface KLButtonObject {
+    title: string;
+    link: KLLinkObject;
+}
+export interface KLCommerceObject {
+    regularPrice: number;
+    discountPrice?: number;
+    discountRate?: number;
+    fixedDiscountPrice?: number;
+}
+export declare enum AuthTypes {
+    AuthTypeTalk = 1,
+    AuthTypeStory,
+    AuthTypeAccount,
+}

--- a/ngx/index.js
+++ b/ngx/index.js
@@ -1,0 +1,119 @@
+import { Injectable } from '@angular/core';
+import { cordova, IonicNativePlugin } from '@ionic-native/core';
+
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+
+var KakaoCordovaSDK = /** @class */ (function(_super) {
+    __extends(KakaoCordovaSDK, _super);
+    function KakaoCordovaSDK() {
+        return (_super !== null && _super.apply(this, arguments)) || this;
+    }
+    KakaoCordovaSDK.prototype.login = function(loginOptions) {
+        return cordova(this, 'login', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.logout = function () {
+        return cordova(this, 'logout', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.unlinkApp = function () {
+        return cordova(this, 'unlinkApp', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.getAccessToken = function () {
+        return cordova(this, 'getAccessToken', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.requestMe = function () {
+        return cordova(this, 'requestMe', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.updateScopes = function (targetScopes) {
+        return cordova(this, 'updateScopes', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.checkScopeStatus = function (targetScopes) {
+        return cordova(this, 'checkScopeStatus', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.requestSendMemo = function (builder) {
+        return cordova(this, 'requestSendMemo', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.addPlusFriend = function (params) {
+        return cordova(this, 'addPlusFriend', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.chatPlusFriend = function (params) {
+        return cordova(this, 'chatPlusFriend', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.chatPlusFriendUrl = function (params) {
+        return cordova(this, 'chatPlusFriendUrl', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkFeed = function (feedTemplate) {
+        return cordova(this, 'sendLinkFeed', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkList = function (listTemplate) {
+        return cordova(this, 'sendLinkList', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkLocation = function (locationTemplate) {
+        return cordova(this, 'sendLinkLocation', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkCommerce = function (listTemplate) {
+        return cordova(this, 'sendLinkCommerce', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkText = function (textTemplate) {
+        return cordova(this, 'sendLinkText', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkScrap = function (scrapTemplate) {
+        return cordova(this, 'sendLinkScrap', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.sendLinkCustom = function (customTemplate) {
+        return cordova(this, 'sendLinkCustom', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.uploadImage = function (uploadImageConfig) {
+        return cordova(this, 'uploadImage', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.deleteUploadedImage = function (deleteImageConfig) {
+        return cordova(this, 'deleteUploadedImage', {}, arguments);
+    };
+    KakaoCordovaSDK.prototype.postStory = function (postStoryConfig) {
+        return cordova(this, 'postStory', {}, arguments);
+    };
+    KakaoCordovaSDK.pluginName = 'Kakao Cordova SDK Plugin';
+    KakaoCordovaSDK.plugin = 'cordova-plugin-kakao-sdk';
+    KakaoCordovaSDK.pluginRef = 'KakaoCordovaSDK';
+    KakaoCordovaSDK.repo = 'https://github.com/raccoondev85/cordova-plugin-kakao-sdk';
+    KakaoCordovaSDK.platforms = ['Android', 'iOS'];
+    KakaoCordovaSDK = __decorate([
+        Injectable()
+    ], KakaoCordovaSDK);
+    return KakaoCordovaSDK;
+})(IonicNativePlugin);
+export { KakaoCordovaSDK };
+
+export var AuthTypes;
+(function(AuthTypes) {
+    AuthTypes[(AuthTypes['AuthTypeTalk'] = 1)] = 'AuthTypeTalk';
+    AuthTypes[(AuthTypes['AuthTypeStory'] = 2)] = 'AuthTypeStory';
+    AuthTypes[(AuthTypes['AuthTypeAccount'] = 3)] = 'AuthTypeAccount';
+})(AuthTypes || (AuthTypes = {}));
+export var ScrapType;
+(function(ScrapType) {
+    ScrapType[(ScrapType['ScrapTypeNone'] = 0)] = 'ScrapTypeNone';
+    ScrapType[(ScrapType['ScrapTypeWebsite'] = 1)] = 'ScrapTypeWebsite';
+    ScrapType[(ScrapType['ScrapTypeVideo'] = 2)] = 'ScrapTypeVideo';
+    ScrapType[(ScrapType['ScrapTypeMusic'] = 3)] = 'ScrapTypeMusic';
+    ScrapType[(ScrapType['ScrapTypeBook'] = 4)] = 'ScrapTypeBook';
+    ScrapType[(ScrapType['ScrapTypeArticle'] = 5)] = 'ScrapTypeArticle';
+    ScrapType[(ScrapType['ScrapTypeProfile'] = 6)] = 'ScrapTypeProfile';
+})(ScrapType || (ScrapType = {}));


### PR DESCRIPTION
Ionic 4 use @ionic-native/core@5.x.x.
Since version 5 [**C**ordova function](https://github.com/ionic-team/ionic-native/blob/v3.x/src/%40ionic-native/core/decorators.ts) to call a Cordova plugin no longer exists.
This function being used in index.js, it creates this error

> TypeError: Object(...) is not a function

This pull request updates the project to use [**c**ordova function](https://github.com/ionic-team/ionic-native/blob/v5/src/%40ionic-native/core/decorators/cordova.ts) that appeared from version 5 of @ionic-native/core.

To import the injectable class, you can use the /ngx directory (like @ionic-native plugins) as shown in the following examples :

`import { KakaoCordovaSDK } from 'kakao-sdk/ngx';`